### PR TITLE
fix: use a more generic powershell error fragment for Windows probing

### DIFF
--- a/pkg/process/errors.go
+++ b/pkg/process/errors.go
@@ -23,7 +23,10 @@ const (
 	// windowsPowershellCommandNotFoundFragment is a fragment of the error output
 	// returned on Windows systems running Powershell when a command cannot be
 	// found.
-	windowsPowershellCommandNotFoundFragment = "is not recognized as the name of a cmdlet, function, script file, or operable program."
+	// Different Windows versions use slightly error messages.
+	// i.e. "is not recognized as the name of a cmdlet, function, script file, or operable program."
+	//      "is not recognized as a name of a cmdlet, function, script file, or executable program."
+	windowsPowershellCommandNotFoundFragment = "cmdlet, function, script file, or"
 )
 
 // OutputIsPOSIXCommandNotFound returns whether or not a process' error output


### PR DESCRIPTION
Closes https://github.com/coder/internal/issues/566

Very very funny to me that someone at Microsoft changed this error message, especially the "a name" <=> "the name".

File sync working:
![image](https://github.com/user-attachments/assets/1901d00b-f8a4-489c-8b99-b9e62ea7e1fd)
