### PR TITLE
feat: allow specifying SSH config path via a daemon environment variable

### DIFF
--- a/pkg/agent/transport/ssh/transport.go
+++ b/pkg/agent/transport/ssh/transport.go
@@ -156,6 +156,10 @@ func (t *sshTransport) Command(command string) (*exec.Cmd, error) {
 	// more efficient to compress at that layer, even with the slower Go
 	// implementation.
 	var sshArguments []string
+	if configPath := os.Getenv("MUTAGEN_SSH_CONFIG_PATH"); configPath != "" {
+		// According to `man ssh`, "none" is also a valid value for `-F`
+		sshArguments = append(sshArguments, "-F", configPath)
+	}
 	sshArguments = append(sshArguments, ssh.ConnectTimeoutFlag(connectTimeoutSeconds))
 	sshArguments = append(sshArguments, ssh.ServerAliveFlags(serverAliveIntervalSeconds, serverAliveCountMax)...)
 	if t.port != 0 {

--- a/pkg/mutagen/version.go
+++ b/pkg/mutagen/version.go
@@ -15,7 +15,7 @@ const (
 	// VersionMinor represents the current minor version of Mutagen.
 	VersionMinor = 18
 	// VersionPatch represents the current patch version of Mutagen.
-	VersionPatch = 2
+	VersionPatch = 3
 	// VersionTag represents a tag to be appended to the Mutagen version string.
 	// It must not contain spaces. If empty, no tag is appended to the version
 	// string.

--- a/pkg/process/errors.go
+++ b/pkg/process/errors.go
@@ -23,7 +23,7 @@ const (
 	// windowsPowershellCommandNotFoundFragment is a fragment of the error output
 	// returned on Windows systems running Powershell when a command cannot be
 	// found.
-	// Different Windows versions use slightly error messages.
+	// Different Windows versions use slightly different error messages.
 	// i.e. "is not recognized as the name of a cmdlet, function, script file, or operable program."
 	//      "is not recognized as a name of a cmdlet, function, script file, or executable program."
 	windowsPowershellCommandNotFoundFragment = "cmdlet, function, script file, or"


### PR DESCRIPTION
Relates to https://github.com/coder/internal/issues/590

I've tested this manually, and within Coder Desktop macOS, by setting `MUTAGEN_SSH_CONFIG_PATH` to `none`.

From the man page for `ssh(1)`:
```
-F configfile
    [...] If set to “none”, no configuration files will be read.
```

Subsequent PRs for the Desktop apps will use the new Mutagen version (0.18.3), and specify `MUTAGEN_SSH_CONFIG_PATH=none`