### PR TITLE
fix: log every line of multi-line messages

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -85,44 +85,46 @@ const timestampFormat = "2006-01-02 15:04:05.000000"
 
 // write writes a log message to the underlying writer.
 func (l *Logger) write(timestamp time.Time, level Level, message string) {
-	// If a carriage return is found, then truncate the message at that point.
-	if index := strings.IndexByte(message, '\r'); index >= 0 {
-		message = message[:index] + "...\n"
-	}
-
-	// Ensure that the only newline character in the message appears at the end
-	// of the string. If one appears earlier, then truncate the message at that
-	// point. If none appears, then something has gone wrong with formatting.
-	if index := strings.IndexByte(message, '\n'); index < 0 {
+	// Sanity check the message formatting.
+	if !strings.Contains(message, "\n") {
 		panic("no newline character found in formatted message")
-	} else if index != len(message)-1 {
-		message = message[:index] + "...\n"
 	}
 
-	// Compute the log line.
-	var line string
+	// Compute the prefix that identifies the log line.
+	var prefix string
 	if l.scope != "" {
-		line = fmt.Sprintf("%s [%c] [%s] %s",
-			timestamp.Format(timestampFormat), level.abbreviation(), l.scope, message,
+		prefix = fmt.Sprintf("%s [%c] [%s] ",
+			timestamp.Format(timestampFormat), level.abbreviation(), l.scope,
 		)
 	} else {
-		line = fmt.Sprintf("%s [%c] %s",
-			timestamp.Format(timestampFormat), level.abbreviation(), message,
+		prefix = fmt.Sprintf("%s [%c] ",
+			timestamp.Format(timestampFormat), level.abbreviation(),
 		)
 	}
 
-	// Neutralize any control characters in the line.
-	line = terminal.NeutralizeControlCharacters(line)
+	// Write each line of the message as its own log line, carrying the prefix
+	// on each, so that a message spanning multiple lines stays attributable and
+	// intact. Messages carrying process error output are routinely multi-line,
+	// with the cause of a failure appearing after the first symptom of it, so
+	// discarding everything past the first line hides the information that the
+	// log exists to capture. Control characters are neutralized on each line,
+	// which also removes the need to truncate at a carriage return.
+	var lines strings.Builder
+	for _, line := range strings.Split(strings.TrimSuffix(message, "\n"), "\n") {
+		lines.WriteString(terminal.NeutralizeControlCharacters(prefix + line))
+		lines.WriteByte('\n')
+	}
 
-	// Write the line. We can't do much with the error here, so we don't try.
-	// Practically speaking, most io.Writer implementations perform retries if a
-	// short write occurs, so retrying here (on top of that logic) probably
-	// wouldn't help much. Even if we wanted to, we'd be better off wrapping the
-	// writer in a hypothetical RetryingWriter in order to better encapsulate
-	// that logic and to avoid having to add a lock outside the writer. In any
-	// case, Go's standard log package also discards analogous errors, so we'll
-	// do the same for the time being.
-	l.writer.Write([]byte(line))
+	// Write the lines in a single call so that they stay contiguous in the log
+	// when multiple goroutines are logging. We can't do much with the error
+	// here, so we don't try. Practically speaking, most io.Writer
+	// implementations perform retries if a short write occurs, so retrying here
+	// (on top of that logic) probably wouldn't help much. Even if we wanted to,
+	// we'd be better off wrapping the writer in a hypothetical RetryingWriter in
+	// order to better encapsulate that logic and to avoid having to add a lock
+	// outside the writer. In any case, Go's standard log package also discards
+	// analogous errors, so we'll do the same for the time being.
+	l.writer.Write([]byte(lines.String()))
 }
 
 // log provides logging with formatting semantics equivalent to fmt.Sprintln.

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,3 +1,58 @@
 package logging
 
-// TODO: Implement.
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// scpErrorOutput is representative of the stderr that scp produces when the
+// OpenSSH configuration diverts it onto a broken ProxyCommand. The first line
+// is a symptom and the second line is the cause, which makes it a good test of
+// whether the logger preserves everything it is given.
+const scpErrorOutput = "unable to run SCP process: /bin/sh: 1: Syntax error: Bad for loop variable\n" +
+	"/bin/sh: 1: exec: /c/Program Files/Coder/bin/coder.exe: not found\n" +
+	"scp: Connection closed"
+
+func TestLoggerPreservesMultiLineMessages(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	NewLogger(LevelInfo, buffer).Sublogger("sync").Sublogger("sync_IxTbhpj3").Info(scpErrorOutput)
+
+	output := buffer.String()
+	for _, expected := range []string{
+		"Bad for loop variable",
+		"coder.exe: not found",
+		"scp: Connection closed",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("output does not contain %q:\n%s", expected, output)
+		}
+	}
+
+	// Every line needs the level and scope prefix, otherwise continuation
+	// lines cannot be attributed to a session when reading a log.
+	lines := strings.Split(strings.TrimSuffix(output, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 log lines, got %d:\n%s", len(lines), output)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, "[I] [sync.sync_IxTbhpj3]") {
+			t.Errorf("line missing level and scope prefix: %q", line)
+		}
+	}
+}
+
+func TestLoggerNeutralizesCarriageReturns(t *testing.T) {
+	buffer := &bytes.Buffer{}
+	NewLogger(LevelInfo, buffer).Info("progress\roverwritten")
+
+	output := buffer.String()
+	if strings.ContainsRune(output, '\r') {
+		t.Errorf("output contains a raw carriage return: %q", output)
+	}
+	// The text after the carriage return must survive, escaped rather than
+	// discarded.
+	if !strings.Contains(output, `progress\roverwritten`) {
+		t.Errorf("text after carriage return was not preserved: %q", output)
+	}
+}


### PR DESCRIPTION
The daemon log truncates any message at its first newline and appends `...`.
Process error output is routinely multi-line, and the cause of a failure
usually appears after the first symptom of it, so the useful half of the
message was being discarded.

Each line of a message is now written as its own log line carrying the full
timestamp, level, and scope prefix. Neutralizing control characters per line
also makes the separate carriage-return truncation unnecessary.

Found while investigating a customer file sync failure, where the logged
error named a symptom and hid the cause:

```
[I] [sync.sync_IxTbhpj3] Beta connection failure: ... unable to copy agent
binary: unable to run SCP process: /bin/sh: -c: line 1: syntax error near
unexpected token `%a'...
```

<details>
<summary>Before and after, from the test in this PR</summary>

Given scp stderr reproduced locally against a real `sshd`:

```
/bin/sh: 1: Syntax error: Bad for loop variable
/bin/sh: 1: exec: /c/Program Files/Coder/bin/coder.exe: not found
scp: Connection closed
```

Before, the cause and the outcome are both gone:

```
2026-08-12 23:08:21 [I] [sync.sync_IxTbhpj3] unable to run SCP process: /bin/sh: 1: Syntax error: Bad for loop variable...
```

After:

```
2026-08-12 23:08:21 [I] [sync.sync_IxTbhpj3] unable to run SCP process: /bin/sh: 1: Syntax error: Bad for loop variable
2026-08-12 23:08:21 [I] [sync.sync_IxTbhpj3] /bin/sh: 1: exec: /c/Program Files/Coder/bin/coder.exe: not found
2026-08-12 23:08:21 [I] [sync.sync_IxTbhpj3] scp: Connection closed
```

The test commit is separate from the fix commit, so the failure is visible in
history.

</details>

Notes for the reviewer:

- Lines are written in a single `Write` call so a multi-line record stays
  contiguous when several goroutines log at once.
- `pkg/agent` has two pre-existing test failures on a clean `main`; they need
  a built agent bundle and are unrelated.
- The Commit Verification job will fail. These commits are not
  cryptographically signed, and re-signing them means rewriting history,
  which I am not permitted to do. Existing commits on this fork are also
  missing their sign-off. Happy for someone to re-sign before merge.

---

This PR was created by Coder Agents on behalf of @aslilac.
