### PR TITLE
fix: apply SSH config to SCP

### DIFF
--- a/pkg/agent/transport/ssh/transport.go
+++ b/pkg/agent/transport/ssh/transport.go
@@ -40,6 +40,15 @@ func init() {
 	}
 }
 
+// sshConfigArguments computes SSH configuration arguments.
+func sshConfigArguments() []string {
+	if configPath := os.Getenv("MUTAGEN_SSH_CONFIG_PATH"); configPath != "" {
+		// According to `man ssh`, "none" is also a valid value for `-F`.
+		return []string{"-F", configPath}
+	}
+	return nil
+}
+
 // sshTransport implements the agent.Transport interface using SSH.
 type sshTransport struct {
 	// user is the SSH user under which agents should be invoked.
@@ -96,6 +105,7 @@ func (t *sshTransport) Copy(localPath, remoteName string) error {
 
 	// Set up arguments.
 	var scpArguments []string
+	scpArguments = append(scpArguments, sshConfigArguments()...)
 	scpArguments = append(scpArguments, ssh.CompressionFlag())
 	scpArguments = append(scpArguments, ssh.ConnectTimeoutFlag(connectTimeoutSeconds))
 	scpArguments = append(scpArguments, ssh.ServerAliveFlags(serverAliveIntervalSeconds, serverAliveCountMax)...)
@@ -156,10 +166,7 @@ func (t *sshTransport) Command(command string) (*exec.Cmd, error) {
 	// more efficient to compress at that layer, even with the slower Go
 	// implementation.
 	var sshArguments []string
-	if configPath := os.Getenv("MUTAGEN_SSH_CONFIG_PATH"); configPath != "" {
-		// According to `man ssh`, "none" is also a valid value for `-F`
-		sshArguments = append(sshArguments, "-F", configPath)
-	}
+	sshArguments = append(sshArguments, sshConfigArguments()...)
 	sshArguments = append(sshArguments, ssh.ConnectTimeoutFlag(connectTimeoutSeconds))
 	sshArguments = append(sshArguments, ssh.ServerAliveFlags(serverAliveIntervalSeconds, serverAliveCountMax)...)
 	if t.port != 0 {

--- a/pkg/agent/transport/ssh/transport.go
+++ b/pkg/agent/transport/ssh/transport.go
@@ -43,7 +43,7 @@ func init() {
 // sshConfigArguments computes SSH configuration arguments.
 func sshConfigArguments() []string {
 	if configPath := os.Getenv("MUTAGEN_SSH_CONFIG_PATH"); configPath != "" {
-		// According to `man ssh`, "none" is also a valid value for `-F`.
+		// "none" is treated as a special value: do not load any config file.
 		return []string{"-F", configPath}
 	}
 	return nil

--- a/pkg/agent/transport/ssh/transport_test.go
+++ b/pkg/agent/transport/ssh/transport_test.go
@@ -105,3 +105,16 @@ func TestCommandOutput(t *testing.T) {
 		t.Error("output not in UTF-8 encoding")
 	}
 }
+
+func TestSSHConfigArguments(t *testing.T) {
+	t.Setenv("MUTAGEN_SSH_CONFIG_PATH", "")
+	if arguments := sshConfigArguments(); len(arguments) != 0 {
+		t.Fatal("unexpected SSH configuration arguments:", arguments)
+	}
+
+	t.Setenv("MUTAGEN_SSH_CONFIG_PATH", "none")
+	arguments := sshConfigArguments()
+	if len(arguments) != 2 || arguments[0] != "-F" || arguments[1] != "none" {
+		t.Fatal("unexpected SSH configuration arguments:", arguments)
+	}
+}

--- a/pkg/agent/transport/ssh/transport_test.go
+++ b/pkg/agent/transport/ssh/transport_test.go
@@ -105,16 +105,3 @@ func TestCommandOutput(t *testing.T) {
 		t.Error("output not in UTF-8 encoding")
 	}
 }
-
-func TestSSHConfigArguments(t *testing.T) {
-	t.Setenv("MUTAGEN_SSH_CONFIG_PATH", "")
-	if arguments := sshConfigArguments(); len(arguments) != 0 {
-		t.Fatal("unexpected SSH configuration arguments:", arguments)
-	}
-
-	t.Setenv("MUTAGEN_SSH_CONFIG_PATH", "none")
-	arguments := sshConfigArguments()
-	if len(arguments) != 2 || arguments[0] != "-F" || arguments[1] != "none" {
-		t.Fatal("unexpected SSH configuration arguments:", arguments)
-	}
-}


### PR DESCRIPTION
currently we run `ssh` with `-F none`, indicating that it should not load any config files. we do _not_ run `scp` with that same flag, so it _does_ try to load config files.

we also prioritize git bash's `ssh` and `scp` binaries over the built in window's openssh binaries. those do not handle the `cmd.exe` specific config we generate in `coder config-ssh` well, because they use the `/bin/sh` from their environments when interpreting the `Match host` line.

an easy fix for this is to just tell `scp` to not load any config, same as `ssh`.

eventually I'd also like to raise the bigger point of "I think we should **require** the built-in OpenSSH and only ever use it, to make for a smaller target surface" but I tested this smaller change and it works fine.